### PR TITLE
Fixing package name on tests

### DIFF
--- a/cast_test.go
+++ b/cast_test.go
@@ -1,6 +1,6 @@
 // Public domain.
 
-package cluster_test
+package cluster
 
 import (
 	"fmt"

--- a/dist_matrix_test.go
+++ b/dist_matrix_test.go
@@ -1,6 +1,6 @@
 // Public domain.
 
-package cluster_test
+package cluster
 
 import (
 	"fmt"

--- a/kmeans_test.go
+++ b/kmeans_test.go
@@ -1,7 +1,7 @@
 // Author Sonia Keys 2012
 // Public domain.
 
-package cluster_test
+package cluster
 
 import (
 	"math"


### PR DESCRIPTION
Thanks for the package!

[According to go](https://golang.org/pkg/testing/), the package name on tests should be the same as the package they test.  I don't think this was breaking anything, but I fixed it and tests still work fine.

> To write a new test suite, create a file whose name ends _test.go that contains the TestXxx functions as described here. Put the file in the same package as the one being tested. The file will be excluded from regular package builds but will be included when the “go test” command is run. For more detail, run “go help test” and “go help testflag”.
